### PR TITLE
Defines the identity function as the base case of composition

### DIFF
--- a/compose.py
+++ b/compose.py
@@ -1,3 +1,5 @@
+from functools import reduce
+
 def compose(*fs):
     """
     Create a function composition.
@@ -8,4 +10,4 @@ def compose(*fs):
         f(g(x))``.
     :return: I{callable} taking 1 argument.
     """
-    return reduce(lambda f, g: lambda x: f(g(x)), fs)
+    return reduce(lambda f, g: lambda x: f(g(x)), fs, lambda x: x)

--- a/test_compose.py
+++ b/test_compose.py
@@ -33,3 +33,14 @@ class ComposeTests(TestCase):
         self.assertEqual(
             -3,
             compose(self.add_one, self.times_two, self.minus_three)(1))
+
+    def test_base_case(self):
+        """
+        [It is suggested](https://mathieularose.com/function-composition-in-python/#comment-1929127640)
+        to define a base case for composition: The identity function.
+        So `compose()` should be equal to the identity function *f(x) = x*.
+        """
+        f = compose() # This should not fail
+        self.assertTrue(
+            all(
+                argument == f(argument) for argument in range(-1000, 1001)))


### PR DESCRIPTION
[It is suggested](https://mathieularose.com/function-composition-in-python/#comment-1929127640)
to define a base case for composition: The identity function.
So `compose()` should be equal to the identity function _f(x) = x_.

Also, includes the `from functools import reduce` sentence at the
begining of the compose.py file.
